### PR TITLE
Add color to hex

### DIFF
--- a/Assets/Materials/Hex/VertexColor.mat
+++ b/Assets/Materials/Hex/VertexColor.mat
@@ -7,8 +7,8 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Hex
-  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Name: VertexColor
+  m_Shader: {fileID: 4800000, guid: 223966f9dec215d40a8790f6a396baca, type: 3}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -40,7 +40,7 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 10305, guid: 0000000000000000f000000000000000, type: 0}
+        m_Texture: {fileID: 10307, guid: 0000000000000000f000000000000000, type: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     - _MetallicGlossMap:
@@ -60,8 +60,8 @@ Material:
     - _Cutoff: 0.5
     - _DetailNormalMapScale: 1
     - _DstBlend: 0
-    - _GlossMapScale: 0.457
-    - _Glossiness: 0.482
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
     - _GlossyReflections: 1
     - _Metallic: 0
     - _Mode: 0
@@ -73,5 +73,5 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 0.745283, g: 0.20741367, b: 0.20741367, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}

--- a/Assets/Materials/Hex/VertexColor.mat.meta
+++ b/Assets/Materials/Hex/VertexColor.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 41e10ea5c23f27746a925a672a7212d2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1137,7 +1137,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: 41e10ea5c23f27746a925a672a7212d2, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -1203,11 +1203,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1084510654, guid: 995b44eca46f1b34091f8460d292e69e, type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 1557183882, guid: 995b44eca46f1b34091f8460d292e69e, type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 1560503124, guid: 995b44eca46f1b34091f8460d292e69e, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -1219,7 +1219,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2136080420, guid: 995b44eca46f1b34091f8460d292e69e, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 5674885962095068233, guid: 995b44eca46f1b34091f8460d292e69e,
         type: 3}

--- a/Assets/Scripts/Hex/HexCell.cs
+++ b/Assets/Scripts/Hex/HexCell.cs
@@ -7,5 +7,7 @@ namespace Hex
     public class HexCell : MonoBehaviour
     {
         public HexCoordinates coordinates;
+
+        public Color color;
     }
 }

--- a/Assets/Scripts/Hex/HexColor.cs
+++ b/Assets/Scripts/Hex/HexColor.cs
@@ -1,0 +1,19 @@
+﻿using UnityEngine;
+
+namespace Hex
+{
+    public class HexColor
+    {
+        static Color[] colors = {
+            Color.white,
+            Color.green,
+            Color.yellow,
+            Color.gray,
+        };
+
+        public static Color GetRandomColor()
+        {
+            return colors[Random.Range(0, colors.Length)];
+        }
+    }
+}

--- a/Assets/Scripts/Hex/HexColor.cs
+++ b/Assets/Scripts/Hex/HexColor.cs
@@ -9,6 +9,7 @@ namespace Hex
             Color.green,
             Color.yellow,
             Color.gray,
+            Color.blue
         };
 
         public static Color GetRandomColor()

--- a/Assets/Scripts/Hex/HexColor.cs.meta
+++ b/Assets/Scripts/Hex/HexColor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f33115057100cf347a64a09fade301c6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Hex/HexGrid.cs
+++ b/Assets/Scripts/Hex/HexGrid.cs
@@ -39,6 +39,9 @@ namespace Hex
             cell.transform.SetParent(transform, false);
             cell.transform.localPosition = position;
             cell.coordinates = HexCoordinates.FromOffsetCoordinates(x, z);
+
+            cell.color = HexColor.GetRandomColor();
+
             PrintCellCoordinates(position, cell);
         }
 

--- a/Assets/Scripts/Hex/HexMesh.cs
+++ b/Assets/Scripts/Hex/HexMesh.cs
@@ -13,6 +13,8 @@ namespace Hex
 
         MeshCollider meshCollider;
 
+        List<Color> colors;
+
         void Awake()
         {
             GetComponent<MeshFilter>().mesh = hexMesh = new Mesh();
@@ -21,6 +23,7 @@ namespace Hex
 
             vertices = new List<Vector3>();
             triangles = new List<int>();
+            colors = new List<Color>();
         }
 
         public void Triangulate(HexCell[] cells)
@@ -32,6 +35,7 @@ namespace Hex
             }
 
             hexMesh.vertices = vertices.ToArray();
+            hexMesh.colors = colors.ToArray();
             hexMesh.triangles = triangles.ToArray();
             hexMesh.RecalculateNormals();
 
@@ -51,6 +55,8 @@ namespace Hex
                     center + HexMetrics.corners[i],
                     center + HexMetrics.corners[i + 1]
                 );
+
+                AddColor(cell.color);
             }
         }
 
@@ -69,11 +75,20 @@ namespace Hex
             }
         }
 
+        void AddColor(Color color)
+        {
+            for(int i = 0; i < 3; i++)
+            {
+                colors.Add(color);
+            }
+        }
+
         private void ClearMesh()
         {
             hexMesh.Clear();
             vertices.Clear();
             triangles.Clear();
+            colors.Clear();
         }
 
         public bool isSelected { get; set; }

--- a/Assets/Scripts/Hex/HexMesh.cs
+++ b/Assets/Scripts/Hex/HexMesh.cs
@@ -41,27 +41,32 @@ namespace Hex
         private void Triangulate(HexCell cell)
         {
             Vector3 center = cell.transform.localPosition;
+
             for (int i = 0; i < 6; i++) {
-                AddTriangle(
+                int vertexIndex = vertices.Count;
+                AddTriangles(vertexIndex);
+
+                AddVertices(
                     center,
                     center + HexMetrics.corners[i],
                     center + HexMetrics.corners[i + 1]
-
                 );
             }
         }
 
-        void AddTriangle(Vector3 vertex1, Vector3 vertex2, Vector3 vertex3)
+        void AddVertices(Vector3 vertex1, Vector3 vertex2, Vector3 vertex3)
         {
-            int vertexIndex = vertices.Count;
-
             vertices.Add(vertex1);
             vertices.Add(vertex2);
             vertices.Add(vertex3);
+        }
 
-            triangles.Add(vertexIndex);
-            triangles.Add(vertexIndex + 1);
-            triangles.Add(vertexIndex + 2);
+        void AddTriangles(int vertexIndex)
+        {
+            for(int i = 0; i < 3; i++)
+            {
+                triangles.Add(vertexIndex + i);
+            }
         }
 
         private void ClearMesh()

--- a/Assets/Shaders.meta
+++ b/Assets/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e139ad143bf60d64bbf502677a35eca1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/VertexColors.shader
+++ b/Assets/Shaders/VertexColors.shader
@@ -1,0 +1,54 @@
+﻿Shader "Custom/VertexColors"
+{
+    Properties
+    {
+        _Color ("Color", Color) = (1,1,1,1)
+        _MainTex ("Albedo (RGB)", 2D) = "white" {}
+        _Glossiness ("Smoothness", Range(0,1)) = 0.5
+        _Metallic ("Metallic", Range(0,1)) = 0.0
+    }
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" }
+        LOD 200
+
+        CGPROGRAM
+        // Physically based Standard lighting model, and enable shadows on all light types
+        #pragma surface surf Standard fullforwardshadows
+
+        // Use shader model 3.0 target, to get nicer looking lighting
+        #pragma target 3.0
+
+        sampler2D _MainTex;
+
+        struct Input
+        {
+            float2 uv_MainTex;
+            float4 color : COLOR;
+        };
+
+        half _Glossiness;
+        half _Metallic;
+        fixed4 _Color;
+
+        // Add instancing support for this shader. You need to check 'Enable Instancing' on materials that use the shader.
+        // See https://docs.unity3d.com/Manual/GPUInstancing.html for more information about instancing.
+        // #pragma instancing_options assumeuniformscaling
+        UNITY_INSTANCING_BUFFER_START(Props)
+            // put more per-instance properties here
+        UNITY_INSTANCING_BUFFER_END(Props)
+
+        void surf (Input IN, inout SurfaceOutputStandard o)
+        {
+            // Albedo comes from a texture tinted by color
+            fixed4 c = tex2D (_MainTex, IN.uv_MainTex) * _Color;
+            o.Albedo = c.rgb * IN.color;
+            // Metallic and smoothness come from slider variables
+            o.Metallic = _Metallic;
+            o.Smoothness = _Glossiness;
+            o.Alpha = c.a;
+        }
+        ENDCG
+    }
+    FallBack "Diffuse"
+}

--- a/Assets/Shaders/VertexColors.shader.meta
+++ b/Assets/Shaders/VertexColors.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 223966f9dec215d40a8790f6a396baca
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tests/EditorMode/Hex/HexColorTest.cs
+++ b/Assets/Tests/EditorMode/Hex/HexColorTest.cs
@@ -20,6 +20,7 @@ namespace Tests
                 Color.green,
                 Color.yellow,
                 Color.gray,
+                Color.blue
             };
 
             // Act

--- a/Assets/Tests/EditorMode/Hex/HexColorTest.cs
+++ b/Assets/Tests/EditorMode/Hex/HexColorTest.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Hex;
+using System;
+
+namespace Tests
+{
+    public class HexColorTest
+    {
+
+        [Test]
+        public void Get_Random_Color_From_Color_array()
+        {
+            // Set
+            Color[] possibleColors = {
+                Color.white,
+                Color.green,
+                Color.yellow,
+                Color.gray,
+            };
+
+            // Act
+            Color color = HexColor.GetRandomColor();
+
+            // Assert
+            Assert.True(
+                Array.Exists(
+                    possibleColors,
+                    possibleColor => possibleColor == color
+                )
+            );
+        }
+    }
+}

--- a/Assets/Tests/EditorMode/Hex/HexColorTest.cs.meta
+++ b/Assets/Tests/EditorMode/Hex/HexColorTest.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7231ce2c027316441a16f985f842b4c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# <Feature Title>

- [Adicionar cores aos tiles do mapa](https://trello.com/c/LKJ5jVNy/64-adicionar-cores-aos-tiles-do-mapa)

- This PR adds color to the map hex cells. 
- Creates a HexColor class.
- Assign a random color to each cell when creating each cell. 

![image](https://user-images.githubusercontent.com/9309745/81516097-30c07a80-930d-11ea-99a4-f689089b09a3.png)
